### PR TITLE
refactor: made the store facade type safe

### DIFF
--- a/src/@types/constructor.ts
+++ b/src/@types/constructor.ts
@@ -1,0 +1,2 @@
+export type ConstructorArgs<T> = T extends new (...args: infer U) => any ? U : never;
+export type ConstructorFirstArg<T> = T extends new (arg: infer U, ...args: any[]) => any ? U : never;

--- a/src/store.ts
+++ b/src/store.ts
@@ -1,23 +1,27 @@
-import {EventEmitter} from "events";
+import { EventEmitter } from "events";
 import memorystore from "memorystore";
+import { ConstructorFirstArg } from "./@types/constructor";
 
 
 export class SessionStoreUnavailableException extends Error {
     code: 500
     message: "session store unavailable"
 }
+
+export type StoreConstructor = new (options: any) => StoreInterface
 export interface StoreInterface extends EventEmitter {
-    new(options: any): StoreInterface
     get(id: string, cb?: (err: Error | null, value: any) => void): void
     set(id: string, value: any, cb?: (err: Error | null) => void): void
     destroy(id: string, cb?: (err: Error | null) => void): void
 }
 
-export class StoreFacade {
+export class StoreFacade<T extends StoreConstructor = StoreConstructor> {
     private store: StoreInterface
     private storeReady: boolean = true;
 
-    constructor(store?: (events: {Store: typeof EventEmitter}) => StoreInterface, storeOptions: any = {}) {
+    constructor()
+    constructor(store: (events: {Store: typeof EventEmitter}) => T, storeOptions: ConstructorFirstArg<T>) 
+    constructor(store?: (events: {Store: typeof EventEmitter}) => T, storeOptions?: ConstructorFirstArg<T>) {
         if (!store) {
             store = memorystore as any;
         }

--- a/tests/unit/store.test.ts
+++ b/tests/unit/store.test.ts
@@ -1,0 +1,27 @@
+import { EventEmitter } from "stream"
+import { StoreFacade, StoreInterface } from "../../src/store";
+
+
+
+describe("unit test - store", () => {
+    it("should instantiate a store with config", () => {
+        class DummyClass extends EventEmitter implements StoreInterface {
+            constructor(_config: { foo: string }) {
+                super();
+            }
+            get(_id: string, _cb?: ((err: Error | null, value: any) => void) | undefined): void {
+                throw new Error("Method not implemented.");
+            }
+            set(_id: string, _value: any, _cb?: ((err: Error | null) => void) | undefined): void {
+                throw new Error("Method not implemented.");
+            }
+            destroy(_id: string, _cb?: ((err: Error | null) => void) | undefined): void {
+                throw new Error("Method not implemented.");
+            }
+
+        }
+
+
+        new StoreFacade(() => DummyClass, { foo: "bar" });
+    })
+})


### PR DESCRIPTION
# Enhanced StoreFacade Class Constructor

### Overview
This PR enhances the `StoreFacade` class to provide improved flexibility and type safety in its constructor, accommodating both default and custom store configurations.

### Changes Made
- **Constructor Overloading**: Redefined the constructor of `StoreFacade` to accept different sets of arguments:
  ```typescript
  constructor();
  constructor(store: (events: {Store: typeof EventEmitter}) => T, storeOptions: ConstructorFirstArg<T>);
  constructor(store?: (events: {Store: typeof EventEmitter}) => T, storeOptions?: ConstructorFirstArg<T>);
  ```
  This allows instantiation without arguments or with a custom store function and options.

- **Type Safety**: Introduced type checking to ensure that the `storeOptions` parameter matches the expected configuration for the custom store. This prevents runtime errors by validating properties at compile time.

### Use Cases
1. **Basic Usage**: Instantiate `StoreFacade` without any custom store:
   ```typescript
   new StoreFacade();
   ```
   This initializes `StoreFacade` with default behavior.

2. **Custom Store Example**: Provide a custom store with specific options:
   ```typescript
   new StoreFacade(() => DummyClass, { foo: "bar" });
   ```
   Here, `DummyClass` extends `EventEmitter` and implements `StoreInterface`, ensuring `storeOptions` aligns with the expected configuration (`{ foo: string }`).

   Example:
   ```typescript
   class DummyClass extends EventEmitter implements StoreInterface {
       constructor(_config: { foo: string }) {
           super();
       }
       // Implementation of StoreInterface methods
   }
   ```

### Benefits
- **Type Error Prevention**: Invalid `storeOptions` configurations will trigger type errors during development, safeguarding against runtime failures.
  
- **Improved Developer Experience**: Enables IDE auto-completion for `storeOptions`, enhancing code readability and developer productivity.
